### PR TITLE
Support fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add support for fragments.
+
 ## [1.3.0] - 2019-02-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Robert Knight",
   "license": "MIT",
   "devDependencies": {
+    "@types/array.prototype.flatmap": "^1.2.0",
     "@types/chai": "^4.1.7",
     "@types/jsdom": "^12.2.1",
     "@types/minimist": "^1.2.0",
@@ -35,6 +36,7 @@
     "test": "mocha -r ts-node/register -r test/init.ts test/*.tsx"
   },
   "dependencies": {
+    "array.prototype.flatmap": "^1.2.1",
     "preact-render-to-string": "^4.1.0"
   },
   "files": [

--- a/src/shallow-render-utils.ts
+++ b/src/shallow-render-utils.ts
@@ -1,4 +1,4 @@
-import { ComponentFactory, Component, h, options } from 'preact';
+import { ComponentFactory, Component, Fragment, h, options } from 'preact';
 
 import { PreactComponent, VNodeExtensions } from './preact-internals';
 
@@ -62,7 +62,8 @@ function shallowRenderVNode(vnode: VNodeExtensions) {
   if (
     !shallowRenderActive ||
     typeof vnode.type === 'string' ||
-    vnode.type == null
+    vnode.type == null ||
+    (typeof Fragment !== 'undefined' && vnode.type === Fragment)
   ) {
     return;
   }

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -1,10 +1,11 @@
 import { configure, shallow, mount, render as renderToString } from 'enzyme';
-import { Component, h, options } from 'preact';
+import { Component, Fragment, h, options } from 'preact';
 
 import { assert } from 'chai';
 import * as sinon from 'sinon';
 
 import PreactAdapter from '../src/PreactAdapter';
+import { isPreact10 } from '../src/util';
 
 /**
  * Register tests for static and interactive rendering modes.
@@ -43,6 +44,26 @@ function addStaticTests(render: typeof mount) {
       }
       const wrapper = render(<Widget />);
       assert.equal(wrapper.find('.widget').length, 1);
+    });
+  }
+
+  if (isPreact10() && render !== renderToString) {
+    it('returns contents of fragments', () => {
+      const el = (
+        <div>
+          <Fragment>
+            <span>one</span>
+            <span>two</span>
+            <Fragment>
+              <span>three</span>
+            </Fragment>
+          </Fragment>
+        </div>
+      );
+      const wrapper = render(el)
+        .find('div')
+        .children();
+      assert.equal(wrapper.length, 3);
     });
   }
 }

--- a/test/shallow-render-utils-test.tsx
+++ b/test/shallow-render-utils-test.tsx
@@ -1,8 +1,9 @@
-import { cloneElement, h } from 'preact';
+import { Fragment, cloneElement, h } from 'preact';
 import { assert } from 'chai';
 
 import { getRealType, withShallowRendering } from '../src/shallow-render-utils';
 import { componentForDOMNode, render } from '../src/compat';
+import { isPreact10 } from '../src/util';
 
 describe('shallow-render-utils', () => {
   let container: HTMLElement;
@@ -57,6 +58,20 @@ describe('shallow-render-utils', () => {
       render(el, container);
       assert.equal(container.firstElementChild!.innerHTML, fullOutput);
     });
+
+    if (isPreact10()) {
+      it('does not shallow-render fragments', () => {
+        const el = (
+          <ul>
+            <Fragment>
+              <li>1</li>
+            </Fragment>
+          </ul>
+        );
+        render(el, container);
+        assert.equal(container.innerHTML, '<ul><li>1</li></ul>');
+      });
+    }
   });
 
   describe('getRealType', () => {

--- a/types/preact/index.d.ts
+++ b/types/preact/index.d.ts
@@ -15,4 +15,9 @@ declare module 'preact' {
     ref?: Ref<any>;
     props: P & { children: ComponentChildren };
   }
+
+  /**
+   * Fragment support was introduced in Preact 10.
+   */
+  const Fragment: ComponentConstructor<{}, {}>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,11 @@
     array-from "^2.1.1"
     lodash.get "^4.4.2"
 
+"@types/array.prototype.flatmap@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/array.prototype.flatmap/-/array.prototype.flatmap-1.2.0.tgz#e11283ae3bf9b432173756764064f2d8a7a377b1"
+  integrity sha512-sMRMigmTCA1EVX46F0jPhSFo51uFNo83GkeYlp7r4xKkXwfjkDpTm13vB9Tba4Ey+0rUXX3QjSWHAIwSb3qzrA==
+
 "@types/chai@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.7.tgz#1b8e33b61a8c09cbe1f85133071baa0dbf9fa71a"
@@ -116,6 +121,15 @@ array.prototype.flat@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz#812db8f02cad24d3fab65dd67eabe3b8903494a4"
   integrity sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.10.0"
+    function-bind "^1.1.1"
+
+array.prototype.flatmap@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.1.tgz#3103cd4826ef90019c9b0a4839b2535fa6faf4e9"
+  integrity sha512-i18e2APdsiezkcqDyZor78Pbfjfds3S94dG6dgIV2ZASJaUf1N0dz2tGdrmwrmlZuNUgxH+wz6Z0zYVH2c5xzQ==
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.10.0"


### PR DESCRIPTION
Add support for fragments. The handling of fragments differs between full and
shallow rendering in the React adapters. In "mount"/full renders fragments do
not appear in the RST tree. In shallow renders they do.

This implementation follows the pattern of the full renderers in omitting
fragments from the returned RST tree.

Given a structure like:

```
<ul>
  <Fragment>
    <li/>
    <Fragment>
      <li/>
    </Fragment>
  </Fragment>
</ul>
```

The returned RST tree will look like:

```
<ul>
  <li/>
  <li/>
</ul>
```

The current implementation has a limitation that the root element passed to the
render functions must produce a single RST node. This means that it must either
not be a fragment, or must be a fragment that produces only one child.
Supporting multi-child fragments requires additional work to support the result
of `getNode` possibly being an array everywhere.