### PR TITLE
Make shallow-rendering behaviour more consistent with React

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
 - Add support for simulating errors.
+
+### Fixed
+
+- Shallow rendering now only renders the root element passed to `shallow`,
+  not any child component elements passed in the call to `shallow`.
+
+  In other words `shallow(<Parent><Child/></Parent>)` will render `<Parent>`
+  but only a stub for `<Child>`.
 
 ## [1.4.0] - 2019-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for simulating errors.
 
+### Changed
+
+- Children passed to non-rendered components during shallow-rendering are now
+  present in the output, for consistency with how shallow rendering works in
+  React.
+
 ### Fixed
 
 - Shallow rendering now only renders the root element passed to `shallow`,

--- a/src/ShallowRenderer.ts
+++ b/src/ShallowRenderer.ts
@@ -2,7 +2,11 @@ import { EnzymeRenderer, RSTNode } from 'enzyme';
 import { VNode } from 'preact';
 
 import MountRenderer from './MountRenderer';
-import { withShallowRendering } from './shallow-render-utils';
+import {
+  withShallowRendering,
+  shallowRenderVNodeTree,
+} from './shallow-render-utils';
+import { childElements } from './compat';
 
 export default class ShallowRenderer implements EnzymeRenderer {
   private _mountRenderer: MountRenderer;
@@ -12,6 +16,15 @@ export default class ShallowRenderer implements EnzymeRenderer {
   }
 
   render(el: VNode, context: any, callback?: () => any) {
+    // Make all elements in the input tree, except for the root element, render
+    // to a stub.
+    childElements(el).forEach(el => {
+      if (el != null && typeof el !== 'string') {
+        shallowRenderVNodeTree(el);
+      }
+    });
+
+    // Make any new elements rendered by the root element render to a stub.
     withShallowRendering(() => {
       this._mountRenderer.render(el, context, callback);
 

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -6,7 +6,7 @@
 import { VNode, h, render as preactRender } from 'preact';
 
 import { PreactComponent, PreactNode, PreactVNode } from './preact-internals';
-import { isPreact10 } from './util';
+import { toArray, isPreact10 } from './util';
 
 /**
  * Add `type` and  `props` properties to Preact elements as aliases of
@@ -115,4 +115,19 @@ export function render(el: VNode, container: HTMLElement) {
     const preact9Render = preactRender as any;
     preact9Render(el, container, container.firstChild);
   }
+}
+
+/**
+ * Return the children of a VNode.
+ */
+export function childElements(el: VNode): (VNode | string | null)[] {
+  if (typeof el.children !== 'undefined') {
+    // Preact 8. Children is always an array.
+    return el.children;
+  }
+  if (typeof el.props.children !== 'undefined') {
+    // Preact 10. Children may be a single object.
+    return toArray(el.props.children);
+  }
+  return [];
 }

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -111,12 +111,6 @@ function rstNodeFromComponent(component: PreactComponent): RSTNode {
   // If this was a shallow-rendered component, set the RST node's type to the
   // real component function/class.
   const shallowRenderedType = getRealType(component);
-  if (shallowRenderedType) {
-    // Shallow rendering replaces the output of the component with a dummy
-    // DOM element. Remove this dummy from the RST so that Enzyme does not see
-    // it.
-    rendered = null;
-  }
   const type = shallowRenderedType
     ? shallowRenderedType
     : componentType(component);

--- a/src/shallow-render-utils.ts
+++ b/src/shallow-render-utils.ts
@@ -9,6 +9,7 @@ import {
 
 import { PreactComponent, VNodeExtensions } from './preact-internals';
 import { childElements } from './compat';
+import { isPreact10 } from './util';
 
 interface ShallowRenderFunction extends Function {
   originalType: Function;
@@ -60,8 +61,19 @@ export function getRealType(component: Component) {
 function makeShallowRenderComponent(
   type: ComponentFactory<any>
 ): ShallowRenderFunction {
-  function ShallowRenderStub() {
-    return h('shallow-render', { component: getDisplayName(type) });
+  function ShallowRenderStub({ children }: { children?: any }) {
+    if (isPreact10()) {
+      // Preact 10 can render fragments, so we can return the children directly.
+      return children;
+    }
+    // Older versions of Preact need a dummy DOM element to contain the children.
+    return h(
+      'shallow-render',
+      {
+        component: getDisplayName(type),
+      },
+      children
+    );
   }
   ShallowRenderStub.originalType = type;
   ShallowRenderStub.displayName = getDisplayName(type);

--- a/src/util.ts
+++ b/src/util.ts
@@ -56,3 +56,7 @@ export function withReplacedMethod(
     }
   }
 }
+
+export function toArray(obj: any) {
+  return Array.isArray(obj) ? obj : [obj];
+}

--- a/test/init.ts
+++ b/test/init.ts
@@ -35,3 +35,7 @@ if (opts['preact-lib']) {
 // Log details of which Preact library is being used.
 import { isPreact10 } from '../src/util';
 console.log(`Using Preact ${isPreact10() ? '10+' : '<= 9'}`);
+
+// For Preact <= 9, modify VNode class for compatibility with Preact 10.
+import { addTypeAndPropsToVNode } from '../src/compat';
+addTypeAndPropsToVNode();

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -362,6 +362,20 @@ describe('integration tests', () => {
       // in shallow rendering.
       assert.equal(wrapper.text(), 'One<Child />Three<NestedChild />');
     });
+
+    it('fully renders only the root element', () => {
+      function Component() {
+        return <span>test</span>;
+      }
+      const wrapper = shallow(
+        <div>
+          {/* This should not be rendered as it is not the root component. */}
+          <Component />
+        </div>
+      );
+      const output = wrapper.debug().replace(/\s+/g, '');
+      assert.equal(output, '<div><Component/></div>');
+    });
   });
 
   describe('"string" rendering', () => {

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -376,6 +376,21 @@ describe('integration tests', () => {
       const output = wrapper.debug().replace(/\s+/g, '');
       assert.equal(output, '<div><Component/></div>');
     });
+
+    it('renders children of non-rendered components', () => {
+      function Component() {
+        return null;
+      }
+      const wrapper = shallow(
+        <div>
+          <Component>
+            <p>foo</p>
+          </Component>
+        </div>
+      );
+      const output = wrapper.debug().replace(/\s+/g, '');
+      assert.equal(output, '<div><Component><p>foo</p></Component></div>');
+    });
   });
 
   describe('"string" rendering', () => {

--- a/test/shallow-render-utils-test.tsx
+++ b/test/shallow-render-utils-test.tsx
@@ -1,4 +1,4 @@
-import { Fragment, VNode, cloneElement, h } from 'preact';
+import { Component, Fragment, VNode, cloneElement, h } from 'preact';
 import { assert } from 'chai';
 
 import {
@@ -36,8 +36,13 @@ describe('shallow-render-utils', () => {
   describe('withShallowRendering', () => {
     it('replaces child components with placeholders', () => {
       const fullOutput = 'Hello<span>world</span>';
-      const shallowOutput =
-        'Hello<shallow-render component="Child"></shallow-render>';
+      let shallowOutput: string;
+      if (isPreact10()) {
+        shallowOutput = 'Hello';
+      } else {
+        shallowOutput =
+          'Hello<shallow-render component="Child"></shallow-render>';
+      }
 
       // Normal render should return full output.
       const el = <Component />;
@@ -94,8 +99,15 @@ describe('shallow-render-utils', () => {
       withShallowRendering(() => {
         render(el, container);
       });
-      const child = container.querySelector('shallow-render')!;
-      const childComponent = componentForDOMNode(child)!;
+      let childComponent: Component;
+      if (isPreact10()) {
+        const fragVNode = (container as any)._prevVNode;
+        const rootComponent = fragVNode._children[0]._component;
+        childComponent = rootComponent._prevVNode._children[1]._component;
+      } else {
+        const child = container.querySelector('shallow-render')!;
+        childComponent = componentForDOMNode(child)!;
+      }
       assert.ok(childComponent);
       assert.equal(childComponent instanceof Child, false);
       assert.equal(getRealType(childComponent), Child);

--- a/test/shallow-render-utils-test.tsx
+++ b/test/shallow-render-utils-test.tsx
@@ -1,8 +1,13 @@
-import { Fragment, cloneElement, h } from 'preact';
+import { Fragment, VNode, cloneElement, h } from 'preact';
 import { assert } from 'chai';
 
-import { getRealType, withShallowRendering } from '../src/shallow-render-utils';
-import { componentForDOMNode, render } from '../src/compat';
+import {
+  getRealType,
+  withShallowRendering,
+  isShallowRendered,
+  shallowRenderVNodeTree,
+} from '../src/shallow-render-utils';
+import { componentForDOMNode, render, childElements } from '../src/compat';
 import { isPreact10 } from '../src/util';
 
 describe('shallow-render-utils', () => {
@@ -94,6 +99,31 @@ describe('shallow-render-utils', () => {
       assert.ok(childComponent);
       assert.equal(childComponent instanceof Child, false);
       assert.equal(getRealType(childComponent), Child);
+    });
+  });
+
+  describe('shallowRenderVNodeTree', () => {
+    it('modifies nodes to shallow-render', () => {
+      function Parent() {
+        return null;
+      }
+      function Child() {
+        return null;
+      }
+      const el = (
+        <Parent>
+          <Child />
+        </Parent>
+      );
+      const childEl = childElements(el)[0] as VNode;
+
+      assert.isFalse(isShallowRendered(el));
+      assert.isFalse(isShallowRendered(childEl));
+
+      shallowRenderVNodeTree(el);
+
+      assert.isTrue(isShallowRendered(el));
+      assert.isTrue(isShallowRendered(childEl));
     });
   });
 });


### PR DESCRIPTION
This PR implements two changes to shallow rendering to make the behaviour more consistent with how it works in React. See commit messages for details.