### PR TITLE
Support simulating errors in full and shallow rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Add support for simulating errors.
+
 ## [1.4.0] - 2019-02-19
 
 ### Added

--- a/src/ShallowRenderer.ts
+++ b/src/ShallowRenderer.ts
@@ -40,9 +40,9 @@ export default class ShallowRenderer implements EnzymeRenderer {
     });
   }
 
-  simulateError(node: RSTNode, rootNode: RSTNode, error: any) {
+  simulateError(nodeHierarchy: RSTNode[], rootNode: RSTNode, error: any) {
     withShallowRendering(() => {
-      this._mountRenderer.simulateError(node, rootNode, error);
+      this._mountRenderer.simulateError(nodeHierarchy, rootNode, error);
     });
   }
 

--- a/src/StringRenderer.ts
+++ b/src/StringRenderer.ts
@@ -18,7 +18,7 @@ export default class StringRenderer implements EnzymeRenderer {
     }
   }
 
-  simulateError(node: RSTNode, rootNode: RSTNode, error: any) {
+  simulateError(nodeHierarchy: RSTNode[], rootNode: RSTNode, error: any) {
     throw new Error('Static rendering does not support simulating errors');
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,3 +30,29 @@ export function getDisplayName(node: RSTNode): string {
     return type.displayName || type.name;
   }
 }
+
+/**
+ * Call `fn` with a method on an object temporarily replaced with `methodImpl`.
+ */
+export function withReplacedMethod(
+  obj: any,
+  method: string,
+  methodImpl: Function,
+  fn: Function
+) {
+  const hadOwnMethod = obj.hasOwnProperty(method);
+  const origMethod = obj[method] as Function;
+  if (typeof origMethod !== 'function') {
+    throw new Error(`Expected '${method}' property to be a function`);
+  }
+  obj[method] = methodImpl;
+  try {
+    fn();
+  } finally {
+    if (hadOwnMethod) {
+      obj[method] = origMethod;
+    } else {
+      delete obj[method];
+    }
+  }
+}

--- a/test/MountRenderer_test.tsx
+++ b/test/MountRenderer_test.tsx
@@ -66,6 +66,13 @@ describe('MountRenderer', () => {
       const renderer = new MountRenderer();
       assert.equal(renderer.getNode(), null);
     });
+
+    it('does not return null if root component rendered `null`', () => {
+      const Component = () => null;
+      const renderer = new MountRenderer();
+      renderer.render(<Component />, {});
+      assert.notEqual(renderer.getNode(), null);
+    });
   });
 
   describe('#simulateEvent', () => {

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -7,6 +7,11 @@ import * as sinon from 'sinon';
 import PreactAdapter from '../src/PreactAdapter';
 import { isPreact10 } from '../src/util';
 
+function itIf(cond: () => boolean, description: string, fn: () => any) {
+  const itFn = cond() ? it : it.skip;
+  itFn(description, fn);
+}
+
 /**
  * Register tests for static and interactive rendering modes.
  */
@@ -47,8 +52,8 @@ function addStaticTests(render: typeof mount) {
     });
   }
 
-  if (isPreact10() && render !== renderToString) {
-    it('returns contents of fragments', () => {
+  if (render !== renderToString) {
+    itIf(isPreact10, 'returns contents of fragments', () => {
       const el = (
         <div>
           <Fragment>
@@ -246,6 +251,57 @@ function addInteractiveTests(render: typeof mount) {
     shouldNotCall.forEach(method =>
       sinon.assert.notCalled(Test.prototype[method])
     );
+  });
+
+  itIf(isPreact10, 'supports simulating errors', () => {
+    // let lastError = null;
+
+    function Child() {
+      return <div>Everything is working</div>;
+    }
+
+    class Parent extends Component<any, any> {
+      constructor(props: any) {
+        super(props);
+        this.state = { error: null };
+      }
+
+      render() {
+        const { error } = this.state;
+        if (error) {
+          return <div>Something went wrong: ${error.message}</div>;
+        }
+        return <Child />;
+      }
+
+      componentDidCatch(error: Error) {
+        //  lastError = error;
+      }
+
+      static getDerivedStateFromError(error: Error) {
+        return { error };
+      }
+    }
+
+    const wrapper = render(<Parent />);
+    const expectedText =
+      render === shallow ? '<Child />' : 'Everything is working';
+
+    // Initial render, we should see the original content.
+    assert.equal(wrapper.text(), expectedText);
+
+    // Simulate an error. The placeholder should be shown.
+    const child = wrapper.find(Child);
+    const err = new Error('Boom');
+    child.simulateError(err);
+    assert.equal(wrapper.text(), 'Something went wrong: $Boom');
+    // This assert fails because Preact 10 does not call `componentDidCatch`
+    // if `getDerivedStateFromError` is defined.
+    // assert.equal(lastError, err);
+
+    // Reset the error and render again, we should see the original content.
+    wrapper.setState({ error: null });
+    assert.equal(wrapper.text(), expectedText);
   });
 }
 

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -49,7 +49,7 @@ declare module 'enzyme' {
      */
     getNode(): RSTNode|null;
 
-    simulateError(node: RSTNode, rootNode: RSTNode, error: any): void;
+    simulateError(nodeHierarchy: RSTNode[], rootNode: RSTNode, error: any): void;
 
     /** Simulate an event on a node in the output. */
     simulateEvent(node: RSTNode, event: string, args: Object): void;


### PR DESCRIPTION
In order to make error simulation behave realistically, the
implementation works by temporarily patching the instance's `render`
function with a stub that throws the target exception and then forcing a
re-render. After the render, the stub is removed.

Also fix a bug in testing whether anything was rendered when calling
`MountRenderer#getNode`. It is possible in Preact 10 for a component to
produce no DOM output, so we have to check for metadata on the container
instead.