### PR TITLE
Support methods of Enzyme wrappers which accept JSX trees as arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Support Enzyme wrapper methods which take an element tree as an argument,
+  such as `wrapper.contains(...)`.
+
 ## [1.5.0] - 2019-02-21
 
 ### Added

--- a/src/PreactAdapter.ts
+++ b/src/PreactAdapter.ts
@@ -5,12 +5,13 @@ import {
   JSXElement,
   RSTNode,
 } from 'enzyme';
-import { h } from 'preact';
+import { VNode, h } from 'preact';
 
 import MountRenderer from './MountRenderer';
 import ShallowRenderer from './ShallowRenderer';
 import StringRenderer from './StringRenderer';
 import { addTypeAndPropsToVNode } from './compat';
+import { rstNodeFromElement } from './preact10-rst';
 
 export default class PreactAdapter extends EnzymeAdapter {
   constructor() {
@@ -88,9 +89,6 @@ export default class PreactAdapter extends EnzymeAdapter {
   }
 
   elementToNode(el: JSXElement): RSTNode {
-    // TODO - Convert a Preact VNode which has not been rendered to an RST node.
-    // This is implemented by `elementToTree` in the enzyme-adapter-utils
-    // package.
-    throw new Error('elementToNode is not implemented');
+    return rstNodeFromElement(el as VNode) as RSTNode;
   }
 }

--- a/src/PreactAdapter.ts
+++ b/src/PreactAdapter.ts
@@ -86,4 +86,11 @@ export default class PreactAdapter extends EnzymeAdapter {
   createElement(type: ElementType, props: Object, ...children: JSXElement[]) {
     return h(type as any, props, ...children);
   }
+
+  elementToNode(el: JSXElement): RSTNode {
+    // TODO - Convert a Preact VNode which has not been rendered to an RST node.
+    // This is implemented by `elementToTree` in the enzyme-adapter-utils
+    // package.
+    throw new Error('elementToNode is not implemented');
+  }
 }

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -50,6 +50,39 @@ function addStaticTests(render: typeof mount) {
       const wrapper = render(<Widget />);
       assert.equal(wrapper.find('.widget').length, 1);
     });
+
+    it('can test if result contains subtree', () => {
+      function ListItem({ label }: any) {
+        return <b>{label}</b>;
+      }
+      function List() {
+        return (
+          <ul>
+            <li>
+              <ListItem label="test" />
+            </li>
+          </ul>
+        );
+      }
+      const wrapper = render(<List />);
+
+      assert.isTrue(wrapper.contains(<ListItem label="test" />));
+      assert.isTrue(
+        wrapper.contains(
+          <li>
+            <ListItem label="test" />
+          </li>
+        )
+      );
+      assert.isFalse(wrapper.contains(<ListItem label="foo" />));
+      assert.isFalse(
+        wrapper.contains(
+          <p>
+            <ListItem label="test" />
+          </p>
+        )
+      );
+    });
   }
 
   if (render !== renderToString) {

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -32,7 +32,7 @@ declare module 'enzyme' {
     instance: any;
 
     /** The result of the `render` function from this component. */
-    rendered: Array<RSTNode|string|null>;
+    rendered: Array<RSTNode | string | null>;
   }
 
   /**
@@ -47,9 +47,13 @@ declare module 'enzyme' {
     /**
      * Return a React Standard Tree (RST) representation of the output.
      */
-    getNode(): RSTNode|null;
+    getNode(): RSTNode | null;
 
-    simulateError(nodeHierarchy: RSTNode[], rootNode: RSTNode, error: any): void;
+    simulateError(
+      nodeHierarchy: RSTNode[],
+      rootNode: RSTNode,
+      error: any
+    ): void;
 
     /** Simulate an event on a node in the output. */
     simulateEvent(node: RSTNode, event: string, args: Object): void;
@@ -71,14 +75,28 @@ declare module 'enzyme' {
   /**
    * An adapter that enables Enzyme to work with a specific React-like library.
    */
-  export class EnzymeAdapter {
+  export abstract class EnzymeAdapter {
     options: Object;
 
-    createRenderer(options: AdapterOptions): EnzymeRenderer;
-    nodeToElement(node: RSTNode): JSXElement;
-    isValidElement(el: JSXElement): boolean;
-    createElement(type: ElementType, props: Object, ...children: JSXElement[]): JSXElement;
-    invokeSetStateCallback(instance: any, callback: () => {}): void;
+    // Required methods.
+    abstract createElement(
+      type: ElementType,
+      props: Object,
+      ...children: JSXElement[]
+    ): JSXElement;
+    abstract createRenderer(options: AdapterOptions): EnzymeRenderer;
+    abstract elementToNode(element: JSXElement): RSTNode;
+    abstract isValidElement(el: JSXElement): boolean;
+    abstract nodeToElement(node: RSTNode): JSXElement;
+    abstract nodeToHostNode(node: RSTNode): Node | null;
+
+    // Optional methods.
+    displayNameOfNode?(node: RSTNode): string;
+    invokeSetStateCallback?(instance: any, callback: () => {}): void;
+    isCustomComponentElement?(instance: RSTNode): boolean;
+    isFragment?(node: RSTNode): boolean;
+    isValidElementType?(obj: any): boolean;
+    wrap?(element: JSXElement): JSXElement;
   }
 
   // TODO


### PR DESCRIPTION
Implement the `elementToNode` adapter method. This enables the adapter to support Enzyme wrapper methods which take an element tree as an argument and need to convert it to an RST node for comparison with the rendered tree. For example, `wrapper.contains(<element tree>)`.