### PR TITLE
Update Preact 10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
   - "node"
+script:
+  # Preact 8.x.
+  - yarn test
+  # Preact 10.
+  - yarn test --preact-lib node_modules/preact10/dist/preact.js

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "array.prototype.flatmap": "^1.2.1",
-    "preact-render-to-string": "^4.1.0"
+    "preact-render-to-string": "^4.1.0",
+    "preact10": "npm:preact@10.0.0-alpha0"
   },
   "files": [
     "build/src/**/*"

--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -5,7 +5,7 @@ import { getNode as getNodeClassic } from './preact-rst';
 import { getNode as getNodeV10 } from './preact10-rst';
 import { getDisplayName, isPreact10 } from './util';
 import { render } from './compat';
-import { PreactNode } from './preact-internals';
+import { PreactNode, getRenderedVNode } from './preact-internals';
 import { withReplacedMethod } from './util';
 
 type EventDetails = { [prop: string]: any };
@@ -59,7 +59,7 @@ export default class MountRenderer implements EnzymeRenderer {
       // If the root component rendered null in Preact 10 then the only
       // indicator that content has been rendered will be metadata attached to
       // the container.
-      typeof container._prevVNode === 'undefined'
+      typeof getRenderedVNode(container) === 'undefined'
     ) {
       return null;
     }

--- a/src/preact-internals.ts
+++ b/src/preact-internals.ts
@@ -1,14 +1,26 @@
 import { Component, VNode } from 'preact';
 
 /**
+ * This module provides extended typings for Preact's `Component` and `VNode`
+ * classes which include internal properties.
+ *
+ * The original property names (in the Preact source) are replaced with shorter
+ * ones (they are "mangled") during the build. The mapping from original name to
+ * short name is fixed, see `mangle.json` in the Preact source tree.
+ */
+
+/**
  * An instance of Preact's `Component` class or a subclass created by
  * rendering.
  */
 export interface PreactComponent extends Component {
   // Preact 10.
-  _constructor: Function;
-  _prevVNode: PreactVNode;
-  _vnode: PreactVNode;
+
+  // Original name: `_prevVNode`.
+  __t: PreactVNode;
+
+  // Original name: `_vnode`.
+  __v: PreactVNode;
 
   // Preact <= 9.
   __k: string | null;
@@ -20,7 +32,9 @@ export interface PreactComponent extends Component {
  */
 export interface PreactNode extends ChildNode {
   // Preact 10.
-  _prevVNode: PreactVNode;
+
+  // Original name: `_prevVNode`.
+  __t: PreactVNode;
 
   // Preact <= 9.
   _component: PreactComponent;
@@ -35,9 +49,15 @@ export interface PreactNode extends ChildNode {
 
 export interface PreactVNode extends VNode {
   // Preact 10.
-  _dom: PreactNode | null;
-  _component: PreactComponent | null;
-  _children: PreactVNode[] | null;
+
+  // Original name: `_dom`.
+  __e: PreactNode | null;
+
+  // Original name: `_component`.
+  __c: PreactComponent | null;
+
+  // Original name: `_children`.
+  __k: PreactVNode[] | null;
 }
 
 /**
@@ -45,4 +65,34 @@ export interface PreactVNode extends VNode {
  */
 export interface VNodeExtensions extends VNode {
   originalType: Function;
+}
+
+/**
+ * Return the VNode representing the rendered output of a component.
+ */
+export function getRenderedVNode(
+  componentOrNode: PreactComponent | PreactNode
+) {
+  return componentOrNode.__t;
+}
+
+/**
+ * Return the rendered DOM node associated with a VNode.
+ */
+export function getDOMNode(node: PreactVNode): PreactNode | null {
+  return node.__e;
+}
+
+/**
+ * Return the `Component` instance associated with a VNode.
+ */
+export function getComponent(node: PreactVNode): PreactComponent | null {
+  return node.__c;
+}
+
+/**
+ * Return the child VNodes associated with a VNode.
+ */
+export function getChildren(node: PreactVNode) {
+  return node.__k;
 }

--- a/src/shallow-render-utils.ts
+++ b/src/shallow-render-utils.ts
@@ -39,11 +39,8 @@ function getDisplayName(type: ComponentFactory<any>) {
 export function getRealType(component: Component) {
   let ctor: any;
   const c = component as PreactComponent;
-  if (c._constructor) {
-    ctor = c._constructor;
-  } else {
-    ctor = c.constructor;
-  }
+  ctor = c.constructor;
+
   if (ctor.originalType) {
     return ctor.originalType;
   } else {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,8 @@
 import { RSTNode } from 'enzyme';
 import { VNode, h } from 'preact';
 
+import { PreactVNode } from './preact-internals';
+
 export function getType(obj: Object) {
   if (obj == null) {
     return String(obj);
@@ -9,7 +11,8 @@ export function getType(obj: Object) {
 }
 
 export function isPreact10() {
-  return '_component' in h('div', {});
+  const vnode = h('div', {}) as PreactVNode;
+  return typeof vnode.__c !== 'undefined';
 }
 
 /**

--- a/test/MountRenderer_test.tsx
+++ b/test/MountRenderer_test.tsx
@@ -79,9 +79,7 @@ describe('MountRenderer', () => {
     it('fires an event at the DOM node', () => {
       const renderer = new MountRenderer();
       const callback = sinon.stub();
-      renderer.render(
-        <button type="button" onClick={callback} />,
-      );
+      renderer.render(<button type="button" onClick={callback} />);
 
       renderer.simulateEvent(renderer.getNode() as RSTNode, 'click', {});
 
@@ -91,9 +89,7 @@ describe('MountRenderer', () => {
     it('passes arguments to event handler', () => {
       const renderer = new MountRenderer();
       const callback = sinon.stub();
-      renderer.render(
-        <button type="button" onKeyDown={callback} />,
-      );
+      renderer.render(<button type="button" onKeyDown={callback} />);
 
       renderer.simulateEvent(renderer.getNode() as RSTNode, 'keydown', {
         key: 'a',

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -274,7 +274,14 @@ function addInteractiveTests(render: typeof mount) {
     const wrapper = render(<Test />);
     allMethods.forEach(method => Test.prototype[method].reset());
 
-    (options as any).beforeUnmount = sinon.stub();
+    const unmountCallback = sinon.stub();
+
+    // Preact <= 8.
+    (options as any).beforeUnmount = unmountCallback;
+
+    // Preact 10.
+    (options as any).unmount = unmountCallback;
+
     wrapper.unmount();
     sinon.assert.called((options as any).beforeUnmount);
 

--- a/test/shallow-render-utils-test.tsx
+++ b/test/shallow-render-utils-test.tsx
@@ -9,6 +9,12 @@ import {
 } from '../src/shallow-render-utils';
 import { componentForDOMNode, render, childElements } from '../src/compat';
 import { isPreact10 } from '../src/util';
+import {
+  PreactNode,
+  getChildren,
+  getComponent,
+  getRenderedVNode,
+} from '../src/preact-internals';
 
 describe('shallow-render-utils', () => {
   let container: HTMLElement;
@@ -101,9 +107,12 @@ describe('shallow-render-utils', () => {
       });
       let childComponent: Component;
       if (isPreact10()) {
-        const fragVNode = (container as any)._prevVNode;
-        const rootComponent = fragVNode._children[0]._component;
-        childComponent = rootComponent._prevVNode._children[1]._component;
+        const fragVNode = getRenderedVNode(
+          (container as unknown) as PreactNode
+        );
+        const rootComponent = getComponent(getChildren(fragVNode)![0])!;
+        const rootOutput = getRenderedVNode(rootComponent);
+        childComponent = getComponent(getChildren(rootOutput)![1])!;
       } else {
         const child = container.querySelector('shallow-render')!;
         childComponent = componentForDOMNode(child)!;

--- a/yarn.lock
+++ b/yarn.lock
@@ -735,6 +735,11 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -850,6 +855,13 @@ lolex@^3.0.0:
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
   integrity sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==
 
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
+
 make-error@^1.1.1:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
@@ -961,6 +973,11 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-inspect@^1.6.0:
   version "1.6.0"
@@ -1084,6 +1101,13 @@ preact-render-to-string@^4.1.0:
   dependencies:
     pretty-format "^3.8.0"
 
+"preact10@npm:preact@10.0.0-alpha0":
+  version "10.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-alpha.0.tgz#24f35f5bd47c81387f4ee99517fc5c2320dbafa0"
+  integrity sha512-GO2JTMOuoys4m3652dEv8knD+F36LMCA37aIgCeHjsF6hGkNQJcV68qmRDdEFy79lsJcoaa+me8SGc4AOWnllg==
+  dependencies:
+    prop-types "^15.6.2"
+
 preact@^8.4.2:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.4.2.tgz#1263b974a17d1ea80b66590e41ef786ced5d6a23"
@@ -1103,6 +1127,15 @@ pretty-format@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
   integrity sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=
+
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 psl@^1.1.24, psl@^1.1.28:
   version "1.1.31"
@@ -1143,6 +1176,11 @@ randexp@0.4.6:
   dependencies:
     discontinuous-range "1.0.0"
     ret "~0.1.10"
+
+react-is@^16.8.1:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
+  integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
 
 readable-stream@^3.0.6:
   version "3.1.1"


### PR DESCRIPTION
Update the adapter to support the current Preact 10 alpha. See commit message for details. Now that the alpha has been published, also run the tests against Preact 10 on Travis.