### PR TITLE
Mark Preact 10 as a dev dependency rather than a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2019-03-05
+
+### Fixed
+
+- Fix repository link in package.json
+
+- Mark Preact 10 as a dev dependency rather than a runtime dependency and fix
+  the version number
+
 ## [1.7.0] - 2019-03-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mocha": "^5.2.0",
     "pirates": "^4.0.1",
     "preact": "^8.4.2",
+    "preact10": "npm:preact@10.0.0-alpha.0",
     "prettier": "1.16.4",
     "sinon": "^7.2.3",
     "ts-node": "^8.0.2",
@@ -27,7 +28,7 @@
   },
   "peerDependencies": {
     "enzyme": "^3.8.0",
-    "preact": "^8.4.2"
+    "preact": "^8.4.2 || ^10.0.0-alpha"
   },
   "scripts": {
     "build": "tsc",
@@ -37,8 +38,7 @@
   },
   "dependencies": {
     "array.prototype.flatmap": "^1.2.1",
-    "preact-render-to-string": "^4.1.0",
-    "preact10": "npm:preact@10.0.0-alpha0"
+    "preact-render-to-string": "^4.1.0"
   },
   "files": [
     "build/src/**/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,7 +1101,7 @@ preact-render-to-string@^4.1.0:
   dependencies:
     pretty-format "^3.8.0"
 
-"preact10@npm:preact@10.0.0-alpha0":
+"preact10@npm:preact@10.0.0-alpha.0":
   version "10.0.0-alpha.0"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-alpha.0.tgz#24f35f5bd47c81387f4ee99517fc5c2320dbafa0"
   integrity sha512-GO2JTMOuoys4m3652dEv8knD+F36LMCA37aIgCeHjsF6hGkNQJcV68qmRDdEFy79lsJcoaa+me8SGc4AOWnllg==


### PR DESCRIPTION
Also fix a typo in the version number, which failed to break the CI
build!