### PR TITLE
Encapsulate access to Preact internals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ script:
   # Preact 8.x.
   - yarn test
   # Preact 10.
-  - yarn test --preact-lib node_modules/preact10/dist/preact.js
+  - yarn test:preact10

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "build": "tsc",
     "format": "prettier --write src/**/*.{ts,tsx} test/**/*.{ts,tsx}",
     "prepublish": "rm -rf build && yarn run build",
-    "test": "mocha -r ts-node/register -r test/init.ts test/*.tsx"
+    "test": "mocha -r ts-node/register -r test/init.ts test/*.tsx",
+    "test:preact10": "yarn test --preact-lib node_modules/preact10/dist/preact.js"
   },
   "dependencies": {
     "array.prototype.flatmap": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mocha": "^5.2.0",
     "pirates": "^4.0.1",
     "preact": "^8.4.2",
-    "preact10": "npm:preact@10.0.0-alpha.0",
+    "preact10": "npm:preact@10.0.0-alpha.1",
     "prettier": "1.16.4",
     "sinon": "^7.2.3",
     "ts-node": "^8.0.2",

--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -5,7 +5,7 @@ import { getNode as getNodeClassic } from './preact-rst';
 import { getNode as getNodeV10 } from './preact10-rst';
 import { getDisplayName, isPreact10 } from './util';
 import { render } from './compat';
-import { PreactNode, getRenderedVNode } from './preact-internals';
+import { getRenderedVNode } from './preact-internals';
 import { withReplacedMethod } from './util';
 
 type EventDetails = { [prop: string]: any };
@@ -52,9 +52,9 @@ export default class MountRenderer implements EnzymeRenderer {
   }
 
   getNode() {
-    const container = (this._container as unknown) as PreactNode;
+    const container = this._container;
     if (
-      // Preact 9 requires DOM nodes to represent any rendered content.
+      // Preact 8 requires DOM nodes to represent any rendered content.
       container.childNodes.length === 0 &&
       // If the root component rendered null in Preact 10 then the only
       // indicator that content has been rendered will be metadata attached to

--- a/src/preact-internals.ts
+++ b/src/preact-internals.ts
@@ -1,8 +1,8 @@
 import { Component, VNode } from 'preact';
 
 /**
- * This module provides extended typings for Preact's `Component` and `VNode`
- * classes which include internal properties.
+ * This module provides access to internal properties of Preact 10 VNodes,
+ * components and DOM nodes rendered by Preact.
  *
  * The original property names (in the Preact source) are replaced with shorter
  * ones (they are "mangled") during the build. The mapping from original name to
@@ -13,43 +13,23 @@ import { Component, VNode } from 'preact';
  * An instance of Preact's `Component` class or a subclass created by
  * rendering.
  */
-export interface PreactComponent extends Component {
-  // Preact 10.
-
+interface PreactComponent extends Component {
   // Original name: `_prevVNode`.
   __t: PreactVNode;
 
   // Original name: `_vnode`.
   __v: PreactVNode;
-
-  // Preact <= 9.
-  __k: string | null;
-  __r: Function | null;
 }
 
 /**
  * A DOM element or text node created by Preact as a result of rendering.
  */
-export interface PreactNode extends ChildNode {
-  // Preact 10.
-
+interface PreactNode extends ChildNode {
   // Original name: `_prevVNode`.
   __t: PreactVNode;
-
-  // Preact <= 9.
-  _component: PreactComponent;
-  _componentConstructor: Function;
-
-  /** The normalized (lower-cased) DOM node name. */
-  __n: string;
-
-  /** Props used to render a DOM node. */
-  __preactattr_: Object;
 }
 
-export interface PreactVNode extends VNode {
-  // Preact 10.
-
+interface PreactVNode extends VNode {
   // Original name: `_dom`.
   __e: PreactNode | null;
 
@@ -61,38 +41,40 @@ export interface PreactVNode extends VNode {
 }
 
 /**
- * Additional properties added to Preact VNode elements by the adapter.
+ * Return the VNode representing the rendered output of a component.
  */
-export interface VNodeExtensions extends VNode {
-  originalType: Function;
+export function getRenderedVNode(componentOrNode: Component | Node) {
+  return (componentOrNode as PreactComponent).__t;
 }
 
 /**
- * Return the VNode representing the rendered output of a component.
+ * Return the VNode that rendered a component.
+ *
+ * Note that this is the VNode that caused the component to be rendered, _not_
+ * the VNodes that were rendered by the component's `render` function. That can
+ * be obtained using `getRenderedVNode`.
  */
-export function getRenderedVNode(
-  componentOrNode: PreactComponent | PreactNode
-) {
-  return componentOrNode.__t;
+export function getVNode(component: Component) {
+  return (component as PreactComponent).__v;
 }
 
 /**
  * Return the rendered DOM node associated with a VNode.
  */
-export function getDOMNode(node: PreactVNode): PreactNode | null {
-  return node.__e;
+export function getDOMNode(node: VNode): PreactNode | null {
+  return (node as PreactVNode).__e;
 }
 
 /**
  * Return the `Component` instance associated with a VNode.
  */
-export function getComponent(node: PreactVNode): PreactComponent | null {
-  return node.__c;
+export function getComponent(node: VNode): PreactComponent | null {
+  return (node as PreactVNode).__c;
 }
 
 /**
  * Return the child VNodes associated with a VNode.
  */
-export function getChildren(node: PreactVNode) {
-  return node.__k;
+export function getChildren(node: VNode) {
+  return (node as PreactVNode).__k;
 }

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -14,13 +14,11 @@ import flatMap from 'array.prototype.flatmap';
 
 import { childElements } from './compat';
 import {
-  PreactComponent,
-  PreactNode,
-  PreactVNode,
   getComponent,
   getChildren,
   getDOMNode,
   getRenderedVNode,
+  getVNode,
 } from './preact-internals';
 import { getRealType } from './shallow-render-utils';
 import { getType } from './util';
@@ -43,19 +41,17 @@ function convertDOMProps(props: Props) {
   return converted;
 }
 
-function rstNodesFromChildren(nodes: PreactVNode[] | null): RSTNodeTypes[] {
+function rstNodesFromChildren(nodes: VNode[] | null): RSTNodeTypes[] {
   if (!nodes) {
     return [];
   }
-  return flatMap(nodes, (node: PreactVNode | null) => {
+  return flatMap(nodes, (node: VNode | null) => {
     const rst = rstNodeFromVNode(node);
     return Array.isArray(rst) ? rst : [rst];
   });
 }
 
-function rstNodeFromVNode(
-  node: PreactVNode | null
-): RSTNodeTypes | RSTNodeTypes[] {
+function rstNodeFromVNode(node: VNode | null): RSTNodeTypes | RSTNodeTypes[] {
   if (node == null) {
     return null;
   }
@@ -136,7 +132,7 @@ export function rstNodeFromElement(node: VNode | null | string): RSTNodeTypes {
 /**
  * Return a React Standard Tree (RST) node from a Preact `Component` instance.
  */
-function rstNodeFromComponent(component: PreactComponent): RSTNode {
+function rstNodeFromComponent(component: Component): RSTNode {
   if (!(component instanceof Component)) {
     throw new Error(
       `Expected argument to be a Component but got ${getType(component)}`
@@ -165,12 +161,14 @@ function rstNodeFromComponent(component: PreactComponent): RSTNode {
     renderedArray = [];
   }
 
+  const vnode = getVNode(component);
+
   return {
     nodeType,
     type,
     props: { children: [], ...component.props },
-    key: component.__v.key || null,
-    ref: component.__v.ref || null,
+    key: vnode.key || null,
+    ref: vnode.ref || null,
     instance: component,
     rendered: renderedArray,
   };
@@ -180,7 +178,7 @@ function rstNodeFromComponent(component: PreactComponent): RSTNode {
  * Convert the Preact components rendered into `container` into an RST node.
  */
 export function getNode(container: HTMLElement): RSTNode {
-  const vnode = getRenderedVNode((container as unknown) as PreactNode);
+  const vnode = getRenderedVNode(container);
   const rstNode = rstNodeFromVNode(vnode);
 
   // There is currently a requirement that the root element produces a single

--- a/src/preact8-internals.ts
+++ b/src/preact8-internals.ts
@@ -1,0 +1,38 @@
+import { Component } from 'preact';
+
+/**
+ * This module provides access to internal properties of Preact 8 components and
+ * DOM nodes rendered by Preact.
+ *
+ * The original property names (in the Preact source) are replaced with shorter
+ * ones (they are "mangled") during the build.
+ */
+
+interface Preact8Component extends Component {
+  // Preact <= 8.
+  __k: string | null;
+  __r: Function | null;
+}
+
+interface Preact8Node extends ChildNode {
+  _component: Preact8Component;
+
+  /** Props used to render a DOM node. */
+  __preactattr_: Object;
+}
+
+export function componentForNode(node: Node) {
+  return (node as Preact8Node)._component;
+}
+
+export function propsForNode(node: Node) {
+  return (node as Preact8Node).__preactattr_ || {};
+}
+
+export function componentKey(component: Component) {
+  return (component as Preact8Component).__k;
+}
+
+export function componentRef(component: Component) {
+  return (component as Preact8Component).__r;
+}

--- a/src/shallow-render-utils.ts
+++ b/src/shallow-render-utils.ts
@@ -7,11 +7,17 @@ import {
   options,
 } from 'preact';
 
-import { PreactComponent, VNodeExtensions } from './preact-internals';
 import { childElements } from './compat';
 import { isPreact10 } from './util';
 
 interface ShallowRenderFunction extends Function {
+  originalType: Function;
+}
+
+/**
+ * Additional properties added to Preact VNode elements by the adapter.
+ */
+export interface VNodeExtensions extends VNode {
   originalType: Function;
 }
 
@@ -38,7 +44,7 @@ function getDisplayName(type: ComponentFactory<any>) {
  */
 export function getRealType(component: Component) {
   let ctor: any;
-  const c = component as PreactComponent;
+  const c = component as Component;
   ctor = c.constructor;
 
   if (ctor.originalType) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import { RSTNode } from 'enzyme';
 import { VNode, h } from 'preact';
 
-import { PreactVNode } from './preact-internals';
+import { getComponent } from './preact-internals';
 
 export function getType(obj: Object) {
   if (obj == null) {
@@ -11,8 +11,8 @@ export function getType(obj: Object) {
 }
 
 export function isPreact10() {
-  const vnode = h('div', {}) as PreactVNode;
-  return typeof vnode.__c !== 'undefined';
+  const vnode = h('div', {});
+  return typeof getComponent(vnode) !== 'undefined';
 }
 
 /**

--- a/test/init.ts
+++ b/test/init.ts
@@ -36,6 +36,6 @@ if (opts['preact-lib']) {
 import { isPreact10 } from '../src/util';
 console.log(`Using Preact ${isPreact10() ? '10+' : '<= 9'}`);
 
-// For Preact <= 9, modify VNode class for compatibility with Preact 10.
+// For Preact <= 8, modify VNode class for compatibility with Preact 10.
 import { addTypeAndPropsToVNode } from '../src/compat';
 addTypeAndPropsToVNode();

--- a/test/shallow-render-utils-test.tsx
+++ b/test/shallow-render-utils-test.tsx
@@ -10,7 +10,6 @@ import {
 import { componentForDOMNode, render, childElements } from '../src/compat';
 import { isPreact10 } from '../src/util';
 import {
-  PreactNode,
   getChildren,
   getComponent,
   getRenderedVNode,
@@ -107,9 +106,7 @@ describe('shallow-render-utils', () => {
       });
       let childComponent: Component;
       if (isPreact10()) {
-        const fragVNode = getRenderedVNode(
-          (container as unknown) as PreactNode
-        );
+        const fragVNode = getRenderedVNode(container);
         const rootComponent = getComponent(getChildren(fragVNode)![0])!;
         const rootOutput = getRenderedVNode(rootComponent);
         childComponent = getComponent(getChildren(rootOutput)![1])!;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,10 +1101,10 @@ preact-render-to-string@^4.1.0:
   dependencies:
     pretty-format "^3.8.0"
 
-"preact10@npm:preact@10.0.0-alpha.0":
-  version "10.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-alpha.0.tgz#24f35f5bd47c81387f4ee99517fc5c2320dbafa0"
-  integrity sha512-GO2JTMOuoys4m3652dEv8knD+F36LMCA37aIgCeHjsF6hGkNQJcV68qmRDdEFy79lsJcoaa+me8SGc4AOWnllg==
+"preact10@npm:preact@10.0.0-alpha.1":
+  version "10.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-alpha.1.tgz#0c8ee161fcd23839568cd52487d2dc07ca1b3166"
+  integrity sha512-9mDFKeU8SkepfCcjsoq/lODLKBtjgZj/aGBJaVXTNOEZV5XgOfE2TZQkFWDejE7w/q1qKUh1tJZaAeICxAKJ1g==
   dependencies:
     prop-types "^15.6.2"
 
@@ -1178,9 +1178,9 @@ randexp@0.4.6:
     ret "~0.1.10"
 
 react-is@^16.8.1:
-  version "16.8.3"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
-  integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
+  integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
 
 readable-stream@^3.0.6:
   version "3.1.1"


### PR DESCRIPTION
This PR isolates access to internal/private properties of Preact VNodes, components and DOM elements in {preact, preact8}-internals.ts. The fact that the adapter relies on this access is a risk because the names could change or properties could be removed between non-major releases. Isolating this access is a step towards finding a way to avoid it altogether or at least making it easy to keep up with any changes.