### PR TITLE
Rename functions for accessing render output

### DIFF
--- a/src/MountRenderer.ts
+++ b/src/MountRenderer.ts
@@ -5,7 +5,7 @@ import { getNode as getNodeClassic } from './preact8-rst';
 import { getNode as getNodeV10 } from './preact10-rst';
 import { getDisplayName, isPreact10 } from './util';
 import { render } from './compat';
-import { getRenderedVNode } from './preact10-internals';
+import { getLastVNodeRenderedIntoContainer } from './preact10-internals';
 import { withReplacedMethod } from './util';
 
 type EventDetails = { [prop: string]: any };
@@ -59,7 +59,7 @@ export default class MountRenderer implements EnzymeRenderer {
       // If the root component rendered null in Preact 10 then the only
       // indicator that content has been rendered will be metadata attached to
       // the container.
-      typeof getRenderedVNode(container) === 'undefined'
+      typeof getLastVNodeRenderedIntoContainer(container) === 'undefined'
     ) {
       return null;
     }

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -9,7 +9,8 @@ import {
   getDOMNode,
   getComponent,
   getChildren,
-  getRenderedVNode,
+  getLastRenderOutput,
+  getLastVNodeRenderedIntoContainer,
 } from './preact10-internals';
 
 import { componentForNode } from './preact8-internals';
@@ -81,7 +82,7 @@ function findVNodeForDOM(vnode: VNode, el: Node): VNode | null {
   // Test the rendered output of this vnode.
   const component = getComponent(vnode);
   if (component) {
-    return findVNodeForDOM(getRenderedVNode(component), el);
+    return findVNodeForDOM(getLastRenderOutput(component), el);
   }
 
   return null;
@@ -103,8 +104,9 @@ export function componentForDOMNode(el: Node): Component | null {
   const targetEl = el;
   let parentEl = el.parentNode;
   while (parentEl) {
-    if (getRenderedVNode(parentEl)) {
-      const vnode = findVNodeForDOM(getRenderedVNode(parentEl), targetEl);
+    const rendered = getLastVNodeRenderedIntoContainer(parentEl);
+    if (rendered) {
+      const vnode = findVNodeForDOM(rendered, targetEl);
       if (vnode) {
         return getComponent(vnode);
       }

--- a/src/preact10-internals.ts
+++ b/src/preact10-internals.ts
@@ -16,9 +16,6 @@ import { Component, VNode } from 'preact';
 interface PreactComponent extends Component {
   // Original name: `_prevVNode`.
   __t: VNode;
-
-  // Original name: `_vnode`.
-  __v: VNode;
 }
 
 /**
@@ -41,45 +38,36 @@ interface PreactVNode extends VNode {
 }
 
 /**
- * Return the VNode representing the rendered output of a component.
+ * Return the last VNode that was rendered into a container using Preact's
+ * `render` function.
  */
-export function getRenderedVNode(componentOrNode: Component | Node) {
-  // Although these two branches currently access a property with the same name,
-  // keep them because they are accessing different objects.
-  if (componentOrNode instanceof Node) {
-    return (componentOrNode as PreactNode).__t;
-  } else {
-    return (componentOrNode as PreactComponent).__t;
-  }
+export function getLastVNodeRenderedIntoContainer(container: Node) {
+  return (container as PreactNode).__t;
 }
 
 /**
- * Return the VNode that rendered a component.
- *
- * Note that this is the VNode that caused the component to be rendered, _not_
- * the VNodes that were rendered by the component's `render` function. That can
- * be obtained using `getRenderedVNode`.
+ * Return the VNode returned when `component` was last rendered.
  */
-export function getVNode(component: Component) {
-  return (component as PreactComponent).__v;
+export function getLastRenderOutput(component: Component) {
+  return (component as PreactComponent).__t;
 }
 
 /**
- * Return the rendered DOM node associated with a VNode.
+ * Return the rendered DOM node associated with a rendered VNode.
  */
 export function getDOMNode(node: VNode): Node | null {
   return (node as PreactVNode).__e;
 }
 
 /**
- * Return the `Component` instance associated with a VNode.
+ * Return the `Component` instance associated with a rendered VNode.
  */
 export function getComponent(node: VNode): Component | null {
   return (node as PreactVNode).__c;
 }
 
 /**
- * Return the child VNodes associated with a VNode.
+ * Return the child VNodes associated with a rendered VNode.
  */
 export function getChildren(node: VNode) {
   return (node as PreactVNode).__k;

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -14,11 +14,11 @@ import flatMap from 'array.prototype.flatmap';
 
 import { childElements } from './compat';
 import {
-  getComponent,
   getChildren,
+  getComponent,
   getDOMNode,
-  getRenderedVNode,
-  getVNode,
+  getLastRenderOutput,
+  getLastVNodeRenderedIntoContainer,
 } from './preact10-internals';
 import { getRealType } from './shallow-render-utils';
 import { getType } from './util';
@@ -61,7 +61,7 @@ function rstNodeFromVNode(node: VNode | null): RSTNodeTypes | RSTNodeTypes[] {
 
   const component = getComponent(node);
   if (component) {
-    return rstNodeFromComponent(component);
+    return rstNodeFromComponent(node, component);
   }
   if (node.type === Fragment) {
     return rstNodesFromChildren(getChildren(node));
@@ -132,7 +132,7 @@ export function rstNodeFromElement(node: VNode | null | string): RSTNodeTypes {
 /**
  * Return a React Standard Tree (RST) node from a Preact `Component` instance.
  */
-function rstNodeFromComponent(component: Component): RSTNode {
+function rstNodeFromComponent(vnode: VNode, component: Component): RSTNode {
   if (!(component instanceof Component)) {
     throw new Error(
       `Expected argument to be a Component but got ${getType(component)}`
@@ -142,7 +142,7 @@ function rstNodeFromComponent(component: Component): RSTNode {
   const nodeType = nodeTypeFromType(component.constructor);
 
   let rendered: RSTNodeTypes | RSTNodeTypes[] = rstNodeFromVNode(
-    getRenderedVNode(component)
+    getLastRenderOutput(component)
   );
 
   // If this was a shallow-rendered component, set the RST node's type to the
@@ -161,8 +161,6 @@ function rstNodeFromComponent(component: Component): RSTNode {
     renderedArray = [];
   }
 
-  const vnode = getVNode(component);
-
   return {
     nodeType,
     type,
@@ -178,7 +176,7 @@ function rstNodeFromComponent(component: Component): RSTNode {
  * Convert the Preact components rendered into `container` into an RST node.
  */
 export function getNode(container: HTMLElement): RSTNode {
-  const vnode = getRenderedVNode(container);
+  const vnode = getLastVNodeRenderedIntoContainer(container);
   const rstNode = rstNodeFromVNode(vnode);
 
   // There is currently a requirement that the root element produces a single

--- a/src/preact8-internals.ts
+++ b/src/preact8-internals.ts
@@ -9,7 +9,6 @@ import { Component } from 'preact';
  */
 
 interface Preact8Component extends Component {
-  // Preact <= 8.
   __k: string | null;
   __r: Function | null;
 }

--- a/test/shallow-render-utils-test.tsx
+++ b/test/shallow-render-utils-test.tsx
@@ -12,7 +12,8 @@ import { isPreact10 } from '../src/util';
 import {
   getChildren,
   getComponent,
-  getRenderedVNode,
+  getLastRenderOutput,
+  getLastVNodeRenderedIntoContainer,
 } from '../src/preact10-internals';
 
 describe('shallow-render-utils', () => {
@@ -106,9 +107,9 @@ describe('shallow-render-utils', () => {
       });
       let childComponent: Component;
       if (isPreact10()) {
-        const fragVNode = getRenderedVNode(container);
+        const fragVNode = getLastVNodeRenderedIntoContainer(container);
         const rootComponent = getComponent(getChildren(fragVNode)![0])!;
-        const rootOutput = getRenderedVNode(rootComponent);
+        const rootOutput = getLastRenderOutput(rootComponent);
         childComponent = getComponent(getChildren(rootOutput)![1])!;
       } else {
         const child = container.querySelector('shallow-render')!;


### PR DESCRIPTION
Split the function for accessing VNode rendered into a container and
getting the last vnode rendered by a component into two separate
functions. Although these happen to use the same code, they are logically
different operations. This also provides an opportunity to improve the
names to clarify how they are used.

Also remove access to the `__v` property of Component instances which
was not necessary as the code that called this function already had that
VNode available.