### PR TITLE
Rename the package's main export to Adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Changed the name of the package's main export to `Adapter`. The export is
+  also exported under its previous name (`PreactAdapter`) for backwards
+  compatibility
+
 ## [1.8.0] - 2019-03-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ provided by this package:
 
 ```js
 import { configure } from 'enzyme';
-import { PreactAdapter } from 'enzyme-adapter-preact-pure';
+import { Adapter } from 'enzyme-adapter-preact-pure';
 
-configure({ adapter: new PreactAdapter });
+configure({ adapter: new Adapter });
 ```
 
 Once the adapter is configured, you can write Enzyme tests for your Preact

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -13,7 +13,7 @@ import StringRenderer from './StringRenderer';
 import { addTypeAndPropsToVNode } from './compat';
 import { rstNodeFromElement } from './preact10-rst';
 
-export default class PreactAdapter extends EnzymeAdapter {
+export default class Adapter extends EnzymeAdapter {
   constructor() {
     super();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
-import PreactAdapter from './PreactAdapter';
+import Adapter from './Adapter';
 
-export { PreactAdapter };
+export {
+  Adapter,
+  // Alias for backwards compatibility with earlier v1.x releases.
+  Adapter as PreactAdapter,
+};

--- a/test/Adapter_test.tsx
+++ b/test/Adapter_test.tsx
@@ -2,15 +2,15 @@ import { VNode, h } from 'preact';
 import { assert } from 'chai';
 import { RSTNode } from 'enzyme';
 
-import PreactAdapter from '../src/PreactAdapter';
+import Adapter from '../src/Adapter';
 import MountRenderer from '../src/MountRenderer';
 import ShallowRenderer from '../src/ShallowRenderer';
 import StringRenderer from '../src/StringRenderer';
 
-describe('PreactAdapter', () => {
+describe('Adapter', () => {
   it('adds `type` and `props` attributes to VNodes', () => {
     // Add extra properties to vnodes for compatibility with Enzyme.
-    new PreactAdapter();
+    new Adapter();
     const el = h('img', { alt: 'A test image' }) as any;
     assert.equal(el.type, 'img');
     assert.deepEqual(el.props, {
@@ -20,7 +20,7 @@ describe('PreactAdapter', () => {
 
   describe('#createElement', () => {
     it('returns a VNode', () => {
-      const adapter = new PreactAdapter();
+      const adapter = new Adapter();
       const el = adapter.createElement(
         'div',
         { title: 'foo' },
@@ -59,14 +59,14 @@ describe('PreactAdapter', () => {
       },
     ].forEach(({ description, el }) => {
       it(`returns true if element is a valid VNode (${description})`, () => {
-        const adapter = new PreactAdapter();
+        const adapter = new Adapter();
         assert.equal(adapter.isValidElement(el), true);
       });
     });
 
     ['not-a-vnode', null].forEach(el => {
       it('returns false if element is not a valid VNode', () => {
-        const adapter = new PreactAdapter();
+        const adapter = new Adapter();
         assert.equal(adapter.isValidElement(el), false);
       });
     });
@@ -130,7 +130,7 @@ describe('PreactAdapter', () => {
         const renderer = new MountRenderer();
         const el = <button type="button">Click me</button>;
         renderer.render(el);
-        const adapter = new PreactAdapter();
+        const adapter = new Adapter();
         const rstNode = renderer.getNode() as RSTNode;
         assert.deepEqual(
           stripPrivateKeys(adapter.nodeToElement(rstNode)),
@@ -144,7 +144,7 @@ describe('PreactAdapter', () => {
     it('returns DOM node if RSTNode is a "host" node', () => {
       const renderer = new MountRenderer();
       renderer.render(<button type="button">Click me</button>);
-      const adapter = new PreactAdapter();
+      const adapter = new Adapter();
       const hostNode = adapter.nodeToHostNode(renderer.getNode() as RSTNode);
       assert.ok(hostNode);
       assert.equal((hostNode as Node).constructor.name, 'HTMLButtonElement');
@@ -156,7 +156,7 @@ describe('PreactAdapter', () => {
       }
       const renderer = new MountRenderer();
       renderer.render(<Button />);
-      const adapter = new PreactAdapter();
+      const adapter = new Adapter();
       const hostNode = adapter.nodeToHostNode(renderer.getNode() as RSTNode);
       assert.ok(hostNode);
       assert.equal((hostNode as Node).constructor.name, 'HTMLButtonElement');
@@ -165,26 +165,26 @@ describe('PreactAdapter', () => {
 
   describe('#createRenderer', () => {
     it('returns a `MountRenderer` when the mode is "mount"', () => {
-      const adapter = new PreactAdapter();
+      const adapter = new Adapter();
       const renderer = adapter.createRenderer({ mode: 'mount' });
       assert.instanceOf(renderer, MountRenderer);
     });
 
     it('returns a `ShallowRenderer` when the mode is "mount"', () => {
-      const adapter = new PreactAdapter();
+      const adapter = new Adapter();
       const renderer = adapter.createRenderer({ mode: 'shallow' });
       assert.instanceOf(renderer, ShallowRenderer);
     });
 
     it('returns a `StringRenderer` when the mode is "string"', () => {
-      const adapter = new PreactAdapter();
+      const adapter = new Adapter();
       const renderer = adapter.createRenderer({ mode: 'string' });
       assert.instanceOf(renderer, StringRenderer);
     });
 
     it('throws if mode is unsupported', () => {
       const modes = ['unknown'];
-      const adapter = new PreactAdapter();
+      const adapter = new Adapter();
       modes.forEach(mode => {
         assert.throws(() => adapter.createRenderer({ mode } as any));
       });

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -4,7 +4,7 @@ import { Component, Fragment, h, options } from 'preact';
 import { assert } from 'chai';
 import * as sinon from 'sinon';
 
-import PreactAdapter from '../src/PreactAdapter';
+import Adapter from '../src/Adapter';
 import { isPreact10 } from '../src/util';
 
 function itIf(cond: () => boolean, description: string, fn: () => any) {
@@ -347,7 +347,7 @@ function addInteractiveTests(render: typeof mount) {
 
 describe('integration tests', () => {
   before(() => {
-    configure({ adapter: new PreactAdapter() });
+    configure({ adapter: new Adapter() });
   });
 
   describe('"mount" rendering', () => {
@@ -355,7 +355,7 @@ describe('integration tests', () => {
     addInteractiveTests(mount);
 
     it('supports retrieving elements', () => {
-      // Test workaround for bug where `PreactAdapter.nodeToElement` is called
+      // Test workaround for bug where `Adapter.nodeToElement` is called
       // with undefined `this` by `ReactWrapper#get`.
       const wrapper = mount(
         <div>


### PR DESCRIPTION
Rename the main export for consistency with the React adapter packages.
This should make it possible to use this library slightly more easily as
a drop-in replacement for the Enzyme React adapters.

The export is also aliased to the previous name for backwards
compatibility.