### PR TITLE
Fix compatibility with preact/compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Made the Preact 10 adapter compatible with preact/compat by removing an
+  `instanceof Component` check, which breaks if the `Component` class comes
+  from the 'preact/compat' bundle
+- Made the adapter the default export of the package. The previous named exports
+  have been kept for backwards compatibility
+
 ## [1.9.0] - 2019-03-15
 
 - Changed the name of the package's main export to `Adapter`. The export is

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import Adapter from './Adapter';
 
 export {
+  // Non-default exports for backwards compatibility with earlier v1.x releases.
   Adapter,
-  // Alias for backwards compatibility with earlier v1.x releases.
   Adapter as PreactAdapter,
 };
+
+export default Adapter;

--- a/src/preact10-rst.ts
+++ b/src/preact10-rst.ts
@@ -21,7 +21,6 @@ import {
   getLastVNodeRenderedIntoContainer,
 } from './preact10-internals';
 import { getRealType } from './shallow-render-utils';
-import { getType } from './util';
 
 type Props = { [prop: string]: any };
 type RSTNodeTypes = RSTNode | string | null;
@@ -133,12 +132,6 @@ export function rstNodeFromElement(node: VNode | null | string): RSTNodeTypes {
  * Return a React Standard Tree (RST) node from a Preact `Component` instance.
  */
 function rstNodeFromComponent(vnode: VNode, component: Component): RSTNode {
-  if (!(component instanceof Component)) {
-    throw new Error(
-      `Expected argument to be a Component but got ${getType(component)}`
-    );
-  }
-
   const nodeType = nodeTypeFromType(component.constructor);
 
   let rendered: RSTNodeTypes | RSTNodeTypes[] = rstNodeFromVNode(


### PR DESCRIPTION
Make the adapter a better drop-in replacement for the enzyme-adapter-react-* packages by:

- Making the adapter class the default export of the package
- Fixing an issue with apps or libraries using preact/compat rather than preact directly