### PR TITLE
Fix exception when `wrapper.text()` is called on a text node wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fix exception when `wrapper.text()` is called on an Enzyme wrapper around a
+  text node.
+
 ## [1.10.1] - 2019-03-22
 
 - Made the Preact 10 adapter compatible with preact/compat by removing an

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -57,7 +57,14 @@ export default class Adapter extends EnzymeAdapter {
     return h(node.type as any, node.props, ...childElements);
   }
 
-  nodeToHostNode(node: RSTNode): Node | null {
+  nodeToHostNode(node: RSTNode | string): Node | null {
+    if (typeof node === 'string') {
+      // Returning `null` here causes `wrapper.text()` to return nothing for a
+      // wrapper around a `Text` node. That's not intuitive perhaps, but it
+      // matches the React adapters' behaviour.
+      return null;
+    }
+
     if (node.nodeType === 'host') {
       return node.instance;
     } else if (node.rendered.length > 0) {

--- a/test/integration_test.tsx
+++ b/test/integration_test.tsx
@@ -145,6 +145,33 @@ function addInteractiveTests(render: typeof mount) {
     assert.deepEqual(item.props(), { label: 'test', children: [] });
   });
 
+  it('can traverse a tree with text nodes', () => {
+    function Widget() {
+      return (
+        <div>
+          <span>foo</span>
+        </div>
+      );
+    }
+    const wrapper = render(<Widget />);
+    const matches = wrapper
+      .findWhere((n: any) => n.text() === 'foo')
+      .map((n: any) => n.type());
+
+    // The fact that the output here differs between full and shallow rendering
+    // is not intuitive, but it matches the output from the React wrappers.
+    let expected: Array<string | Function | undefined>;
+    if (render === mount) {
+      expected = [Widget, 'div', 'span'];
+    } else if (render === shallow) {
+      expected = ['div', 'span', undefined];
+    } else {
+      expected = [];
+    }
+
+    assert.deepEqual(matches, expected);
+  });
+
   it('can find child components by type', () => {
     function ListItem({ label }: any) {
       return <li>{label}</li>;


### PR DESCRIPTION
The output is not what would intuitively be expected, but it matches the
outputs from the React adapter and is better than not crashing.